### PR TITLE
Add required network permissions to WebView library

### DIFF
--- a/libTLabWebView/src/main/AndroidManifest.xml
+++ b/libTLabWebView/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>


### PR DESCRIPTION
## Summary
- declare the INTERNET permission so the embedded WebView can resolve and reach network hosts
- include ACCESS_NETWORK_STATE to let the runtime report accurate connectivity state to the WebView stack

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da19257e548332b741d94e161d6f00